### PR TITLE
Added fileExt option to generate importable .scss files

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Default value: `icons`
 
 Name of the target css file.
 
+#### options.fileExt
+Type: `String`
+Default value: `css`
+
+File extension of the target file.
+
 #### options.cssPrefix
 Type: `String`
 Default value: `icon-`

--- a/index.js
+++ b/index.js
@@ -38,6 +38,9 @@ module.exports = function (options) {
     if (!options.defaultHeight) {
         options.defaultHeight = '16px';
     }
+    if (!options.fileExt) {
+        options.fileExt = 'css';
+    }
 
     /**
      * Returns encoded string of svg file.
@@ -135,7 +138,7 @@ module.exports = function (options) {
         cb();
     }, function (cb) {
         var cssFile = new gutil.File({
-            path: options.fileName + '.css',
+            path: options.fileName + '.' + options.fileExt,
             contents: new Buffer(cssRules.join('\n'))
         });
         this.push(cssFile);

--- a/test.js
+++ b/test.js
@@ -117,6 +117,26 @@ it('should be able to change css file name', function (done) {
     stream.end();
 });
 
+it('should be able to change the file extension', function (done) {
+    var stream = svgcss({
+        fileExt: 'scss'
+    });
+
+    stream
+       .pipe(streamAssert.length(1))
+       .pipe(streamAssert.first(function (newFile) {
+           var fileContents = newFile.contents.toString();
+           assert.equal(newFile.basename, 'icons.scss');
+       }))
+       .pipe(streamAssert.end(done));
+
+    stream.write(new gutil.File({
+        path: 'collapsed.16x16.svg',
+        contents: new Buffer(testData.collpasedSvg)
+    }));
+    stream.end();
+});
+
 it('should be able to change css prefix', function (done) {
     var stream = svgcss({
         cssPrefix: 'icons-list-'


### PR DESCRIPTION
Hi. 

I needed a way to `@extend` my generated icons, so I added a new option `fileExt` which can be set to `scss`. It's documented, tested and fully backwards compatible. So you can just merge it, which would be great ;)

Regards
Manuel
