### PR TITLE
Allows using custom selector prefix for generated CSS (i.e., #%.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gulp-svg-css 
+# gulp-svg-css
 [![Build Status](https://travis-ci.org/sdl/gulp-svg-css.svg?branch=master)](https://travis-ci.org/sdl/gulp-svg-css)
 [![npm version](https://badge.fury.io/js/gulp-svg-css.svg)](https://badge.fury.io/js/gulp-svg-css)
 [![Dependency Status](https://david-dm.org/sdl/gulp-svg-css.svg)](https://david-dm.org/sdl/gulp-svg-css)
@@ -18,7 +18,7 @@ Example usage of the plugin:
         return gulp
             .src('icons/**/*.svg')
             .pipe(svgmin())
-            .pipe(svgcss({ 
+            .pipe(svgcss({
                 fileName: 'icons',
                 cssPrefix: 'icon-',
                 addSize: false
@@ -48,6 +48,12 @@ Type: `String`
 Default value: `icon-`
 
 A string to prefix all css classes with.
+
+#### options.cssSelector
+Type: `String`
+Default value: `.`
+
+A selector to use for the CSS prefix. This is particularly useful if you're outputting a SASS partial, and would rather use a `%` placeholder selector.
 
 #### options.addSize
 Type: `Boolean`

--- a/index.js
+++ b/index.js
@@ -29,6 +29,9 @@ module.exports = function (options) {
     if (!options.cssPrefix) {
         options.cssPrefix = 'icon-';
     }
+    if (!options.cssSelector) {
+        options.cssSelector = '.';
+    }
     if (!options.addSize) {
         options.addSize = false;
     }
@@ -71,7 +74,7 @@ module.exports = function (options) {
      */
     function buildCssRule(normalizedFileName, encodedSvg, width, height) {
         var cssRule = [];
-        cssRule.push('.' + options.cssPrefix + normalizedFileName + ' {');
+        cssRule.push(options.cssSelector + options.cssPrefix + normalizedFileName + ' {');
         cssRule.push('    background-image: url("data:image/svg+xml;charset=utf8, ' + encodedSvg + '");');
         if (options.addSize) {
             cssRule.push('    width: ' + width + ';');


### PR DESCRIPTION
This is useful for using this plugin with SASS’s % placeholder selector.
